### PR TITLE
siegewar-added fire+explosion protection to banners

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyBlockListener.java
@@ -24,6 +24,7 @@ import com.palmergames.bukkit.towny.war.eventwar.War;
 import com.palmergames.bukkit.towny.war.eventwar.WarUtil;
 import com.palmergames.bukkit.towny.war.flagwar.TownyWar;
 import com.palmergames.bukkit.towny.war.flagwar.TownyWarConfig;
+import com.palmergames.bukkit.towny.war.siegewar.utils.SiegeWarBlockUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -266,6 +267,13 @@ public class TownyBlockListener implements Listener {
 		else {
 			blockTo = block.getRelative(direction.getOppositeFace());
 		}
+
+		if(TownySettings.getWarSiegeEnabled()) {
+			if(SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(block) || SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(blockTo)) {
+				return true;
+			}
+		}
+		
 		Location loc = block.getLocation();
 		Location locTo = blockTo.getLocation();
 		Coord coord = Coord.parseCoord(loc);
@@ -313,7 +321,13 @@ public class TownyBlockListener implements Listener {
 	}
 
 	private boolean onBurn(Block block) {
-
+		
+		if(TownySettings.getWarSiegeEnabled()) {
+			if(SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(block)) {
+				return true;
+			}
+		}
+		
 		Location loc = block.getLocation();
 		Coord coord = Coord.parseCoord(loc);
 		TownyWorld townyWorld;
@@ -428,6 +442,12 @@ public class TownyBlockListener implements Listener {
 	 * @return true if allowed.
 	 */
 	public boolean locationCanExplode(TownyWorld world, Location target) {
+
+		if(TownySettings.getWarSiegeEnabled()) {
+			if(SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(target.getBlock())) {
+				return false;
+			}
+		}
 
 		Coord coord = Coord.parseCoord(target);
 

--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -22,6 +22,7 @@ import com.palmergames.bukkit.towny.utils.CombatUtil;
 import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
 import com.palmergames.bukkit.towny.war.eventwar.War;
 import com.palmergames.bukkit.towny.war.flagwar.TownyWarConfig;
+import com.palmergames.bukkit.towny.war.siegewar.utils.SiegeWarBlockUtil;
 import com.palmergames.bukkit.util.ArraySort;
 import net.citizensnpcs.api.CitizensAPI;
 import org.bukkit.Location;
@@ -742,6 +743,12 @@ public class TownyEntityListener implements Listener {
 	 */
 	public boolean locationCanExplode(TownyWorld world, Location target) {
 
+		if(TownySettings.getWarSiegeEnabled()) {
+			if(SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(target.getBlock())) {
+				return false;
+			}
+		}
+		
 		Coord coord = Coord.parseCoord(target);
 
 		if (world.isWarZone(coord) && !TownyWarConfig.isAllowingExplosionsInWarZone()) {
@@ -889,6 +896,15 @@ public class TownyEntityListener implements Listener {
 			int count = 0;
 
 			for (Block block : blocks) {
+
+				if(TownySettings.getWarSiegeEnabled()) {
+					if(SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(block)) {
+						TownyMessaging.sendDebugMsg("onEntityExplode: Canceled " + event.getEntity().getEntityId() + " from exploding near siege banner");
+						event.setCancelled(true);
+						return;
+					}
+				}
+				
 				Coord coord = Coord.parseCoord(block.getLocation());
 				count++;
 				


### PR DESCRIPTION
**DESCRIPTION**
- The currrent mechanism to prevent destruction of active siege banners is missing protection from fire/explosions/pistons.
- Although the siege would continue to work without issue even if the physical banner block was destroyed, it looks better visually if the banner remains.
- This pull request adds protection for the siege banner from fire + explosions + pistons

**REGRESSION TESTING**
- Set on fire non-banner  PASS
- Explode non-banner PASS
- Use piston with non-banner PASS
- Prevented from setting banner on fine PASS
- Prevented from exploding non-banner PASS
- Prevented from using piston with banner PASS
